### PR TITLE
Fixed _is_chargers_equal

### DIFF
--- a/src/utils/filter_entities.py
+++ b/src/utils/filter_entities.py
@@ -26,10 +26,15 @@ def _is_comments_equal(comment_1: Comment | AddComment, comment_2: Comment | Add
 
 
 def _is_chargers_equal(charger_1: Charger, charger_2: Charger) -> bool:
+    # Directly address the scenario where both chargers have no ocpi_ids
+    if charger_1.ocpi_ids is None and charger_2.ocpi_ids is None:
+        return charger_1.network == charger_2.network
+    # Proceed with comparison if both have ocpi_ids
     return (
         charger_1.network == charger_2.network
+        and charger_1.ocpi_ids is not None
+        and charger_2.ocpi_ids is not None
         and sorted(charger_1.ocpi_ids) == sorted(charger_2.ocpi_ids)
-        if charger_1.ocpi_ids and charger_2.ocpi_ids else True
     )
 
 

--- a/tests/utils/test_is_chargers_equal.py
+++ b/tests/utils/test_is_chargers_equal.py
@@ -9,26 +9,26 @@ from src.utils.filter_entities import (
 charger1 = Charger(network="Network1", ocpi_ids=["ocpi1", "ocpi2"])
 charger2 = Charger(network="Network2", ocpi_ids=["ocpi1", "ocpi2"])
 charger3 = Charger(network="Network1", ocpi_ids=["ocpi1", "ocpi2"])  # Duplicate of charger1
-charger4 = Charger(network="Network3", ocpi_ids=None)  # Unique with no ocpi_ids
+charger4 = Charger(network="Network3", ocpi_ids=None)
 charger5 = Charger(network="Network1", ocpi_ids=["ocpi1", "ocpi3"])
 charger6 = Charger(network="Network1", ocpi_ids=None)
 
 
-@pytest.mark.parametrize("charger1, charger2, expected_result", [
+@pytest.mark.parametrize("test_charger1, test_charger2, expected_result", [
     # Same network, same ocpi_ids
     (charger1, charger3, True),
     # Same network, different ocpi_ids
     (charger1, charger5, False),
     # Different network, same ocpi_ids
     (charger1, charger2, False),
-    # Different network, new charger cpi_ids=None
+    # Different network, new charger ocpi_ids=None
     (charger1, charger4, False),
-    # Same network, new charger cpi_ids=None
+    # Same network, new charger ocpi_ids=None
     (charger1, charger6, False),
-    # Same network, both chargers cpi_ids=None
+    # Same network, both chargers ocpi_ids=None
     (charger4, charger4, True),
-    # Different network, existing charger cpi_ids=None
+    # Different network, existing charger ocpi_ids=None
     (charger4, charger3, False)
 ])
-def test_is_chargers_equal(charger1, charger2, expected_result):
-    assert _is_chargers_equal(charger1, charger2) == expected_result
+def test_is_chargers_equal(test_charger1, test_charger2, expected_result):
+    assert _is_chargers_equal(test_charger1, test_charger2) == expected_result

--- a/tests/utils/test_is_chargers_equal.py
+++ b/tests/utils/test_is_chargers_equal.py
@@ -1,9 +1,6 @@
 import pytest
-from src.utils.filter_entities import (
-    Charger,
-    _is_chargers_equal
-)
 
+from src.utils.filter_entities import Charger, _is_chargers_equal
 
 # Sample chargers for testing
 charger1 = Charger(network="Network1", ocpi_ids=["ocpi1", "ocpi2"])
@@ -30,5 +27,5 @@ charger6 = Charger(network="Network1", ocpi_ids=None)
     # Different network, existing charger ocpi_ids=None
     (charger4, charger3, False)
 ])
-def test_is_chargers_equal(test_charger1, test_charger2, expected_result):
+def test_is_chargers_equal(test_charger1: Charger, test_charger2: Charger, expected_result: bool) -> None:
     assert _is_chargers_equal(test_charger1, test_charger2) == expected_result

--- a/tests/utils/test_is_chargers_equal.py
+++ b/tests/utils/test_is_chargers_equal.py
@@ -1,0 +1,34 @@
+import pytest
+from src.utils.filter_entities import (
+    Charger,
+    _is_chargers_equal
+)
+
+
+# Sample chargers for testing
+charger1 = Charger(network="Network1", ocpi_ids=["ocpi1", "ocpi2"])
+charger2 = Charger(network="Network2", ocpi_ids=["ocpi1", "ocpi2"])
+charger3 = Charger(network="Network1", ocpi_ids=["ocpi1", "ocpi2"])  # Duplicate of charger1
+charger4 = Charger(network="Network3", ocpi_ids=None)  # Unique with no ocpi_ids
+charger5 = Charger(network="Network1", ocpi_ids=["ocpi1", "ocpi3"])
+charger6 = Charger(network="Network1", ocpi_ids=None)
+
+
+@pytest.mark.parametrize("charger1, charger2, expected_result", [
+    # Same network, same ocpi_ids
+    (charger1, charger3, True),
+    # Same network, different ocpi_ids
+    (charger1, charger5, False),
+    # Different network, same ocpi_ids
+    (charger1, charger2, False),
+    # Different network, new charger cpi_ids=None
+    (charger1, charger4, False),
+    # Same network, new charger cpi_ids=None
+    (charger1, charger6, False),
+    # Same network, both chargers cpi_ids=None
+    (charger4, charger4, True),
+    # Different network, existing charger cpi_ids=None
+    (charger4, charger3, False)
+])
+def test_is_chargers_equal(charger1, charger2, expected_result):
+    assert _is_chargers_equal(charger1, charger2) == expected_result


### PR DESCRIPTION
_is_chargers_equal previous version failed test if ocpi_ids=None. Fixed.